### PR TITLE
修复快捷键问题

### DIFF
--- a/智绘教/IdtDrawpad.cpp
+++ b/智绘教/IdtDrawpad.cpp
@@ -47,8 +47,8 @@ LRESULT CALLBACK DrawpadHookCallback(int nCode, WPARAM wParam, LPARAM lParam)
 		{
 			IsHotkeyDown = true;
 
-			if (stateMode.StateModeSelect == StateModeSelectEnum::IdtSelection) ChangeStateModeToPen();
-			else ChangeStateModeToSelection();
+			if (stateMode.StateModeSelect == StateModeSelectEnum::IdtSelection) { state = 1.1; ChangeStateModeToPen(); }
+                        else { state = 1; ChangeStateModeToSelection(); }
 		}
 		else if (IsHotkeyDown && !(KeyBoradDown[VK_CONTROL] || KeyBoradDown[VK_LCONTROL] || KeyBoradDown[VK_RCONTROL]) && !(KeyBoradDown[VK_LWIN] || KeyBoradDown[VK_RWIN]) && !(KeyBoradDown[VK_MENU] || KeyBoradDown[VK_LMENU] || KeyBoradDown[VK_RMENU])) IsHotkeyDown = false;
 


### PR DESCRIPTION
在启用画笔模式并打开画笔调色面板的情况下，按下 Ctrl+Win+Alt 切换到选择模式时，画笔调色面板仍然会继续显示。此次代码提交修复了这个问题，确保用快捷键切换到选择模式后，画笔调色面板不再显示。